### PR TITLE
Ваш первый запрос на слияние.

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,74 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: build-${{ matrix.os }}
+        path: ${{ steps.strings.outputs.build-output-dir }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(iuliia-cpp)
- 
+
 add_executable(${PROJECT_NAME} src/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.5)
 
 project(iuliia-cpp)
  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
-int main() {
-    std::cout << "Ok" << std::endl;
-    system("pause");
+int main(int, char **) {
+    ::std::cout << "Ok" << ::std::endl << ::std::flush;
+    ::system("pause");
+    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,34 @@
 #include <iostream>
+#include <stdexcept>
+
+#ifdef _WIN32
+#include <windows.h>
+
+inline static auto wait_for_any_key_() noexcept(false) {
+    auto const source_ = ::GetStdHandle(STD_INPUT_HANDLE);
+    if (NULL == source_) throw ::std::runtime_error{"NULL == ::GetStdHandle(STD_INPUT_HANDLE)"};
+
+    ::std::clog << "Press any key to exit" << ::std::endl << ::std::flush;
+
+    while (true) {
+        ::INPUT_RECORD buffer_;
+        ::DWORD received_count_ = 0;
+        constexpr static ::DWORD const expected_count_ = 1;
+        if (0 == ::ReadConsoleInput(
+            source_, &buffer_, expected_count_, &received_count_
+        )) throw ::std::runtime_error{"0 == ::ReadConsoleInput(...)"};
+        if (expected_count_ != received_count_) throw ::std::runtime_error{"expected_count_ != received_count_"};
+        if (KEY_EVENT == buffer_.EventType) break;
+    }
+}
+#endif // _WIN32
 
 int main(int, char **) {
     ::std::cout << "Ok" << ::std::endl << ::std::flush;
-    ::system("pause");
+
+#ifdef _WIN32
+    ::wait_for_any_key_();
+#endif // _WIN32
+
     return 0;
 }


### PR DESCRIPTION
Требуется просмотреть все предлагаемые коммиты (описание, изменения файлов каждого коммита), осмыслить их и применить к своему репозиторию.

1. [cmake_minimum_required downgrade to 3.5](https://github.com/ChikovMF/Test-from-nppntt/commit/26ed09fb89d447a886d3cba0efe53dfa358b527f).
Для большей совместимости (т.к. исходный код будет компилироваться не только на Вашей машине) рекомендуется немного занизить требования к версии `cmake`. Судя по скриптам `cmake` прямого ограничения на версию не ниже, чем `3.28` нет и версия `3.5` с ними тоже справится.

2. [added github actions workflow](https://github.com/ChikovMF/Test-from-nppntt/commit/e710f7f723356b6736d4f2e62e3253f6af511f70).
[github actions](https://docs.github.com/ru/actions/learn-github-actions/understanding-github-actions) - это интегрированный в `github` инструмент для автоматизации сборки, тестирования, паблишинга и прочего для Ваших репозиториев. Данный коммит добавляет поддержку автоматической компиляции на 3 виртуальных машинах (linux+gcc, linux+clang, windows+msvc).

3. [CMakeLists.txt - decoration changes](https://github.com/ChikovMF/Test-from-nppntt/commit/7004f78c4aac079749747e907c0c529f70fdf9a7).
Файл приведён к виду негласного соглашения о "спейсингах" (переводы каретки, пробелы, табы и пр.). Культура оформления файлов - один из способов не "раскидывать грабли" у себя под ногами в самом начале пути. Правильно оформленные файлы не требуют особенного внимания к себе в процессе их обработки, что экономит ваше время и время других связанных с вашим проектом разработчиков.
3.1. Устранены ненужные пробелы в конце строк.
3.2. Добавлено пустая новая строка в конце файла.

4. [src/main.cpp - refactored](https://github.com/ChikovMF/Test-from-nppntt/commit/ae4d9196db28230ad5afca8b2eefb00ee5947510).
4.1. decoration
   - new line added at the end of the file (аналогично пункту 3).
   - explicit `::` before names from global namespace (в c++ обращение к корневому namespace - `::`, хотя этому правилу мало кто следует).
4.2. explicit signature declaration - `main(int, char **)`. Для функции `main` лучше использовать "строгий" прототип: `int main(int, char**)`. В целом это не сложно, зато может сильно упростить жизнь. Компиляторы бывают разные, а кроме компиляторов эти исходники могут интерпретировать и другие утилиты, которые знают `c++` не на столько хорошо, как вы. Как вы видите, у параметров функции `main` не указаны имена - это сделано потому что эти аргументы пока не используются по коду. `C++` строгий язык - в том числе неиспользуемые, но объявленные имена в нём - плохой тон.
4.3. explicit `::std::flush` for console in interactive mode. Канала вывода у нас 2 (`stdout` и `stderr`). В случае интерактивного исполнения используется их микс - эмулятор терминала, например (чаще всего для пользователя это 1 канал). Возврат управления после инструкции `::std::cout << ...` не означает, что всё то, что вы в него отправили будет отпечатано в терминале на данный момент. `::std::flush` - это инструкция для синхронизации вывода (наподобие безопасного отключения флешки в `windows`).
4.4. `main(...)` - `return 0` by default added. Не будем кормить бога хаоса без особой на то необходимости. Корректно отработавшее приложение (в подавляющем большинстве случаев) возвращает 0. В случае ошибки возвращается ненулевое значение (код ошибки).

5. [src/main.cpp - ugly windows-way console manipulations](https://github.com/ChikovMF/Test-from-nppntt/commit/d2f888fe714b63f3ba585611be34c8e317ae3328).
`system("pause")` - работает, но далеко не везде - в целом это далеко не лучшее решение. По ряду причин в общем случае ожидать от пользователя нажатия клавиши без особых на то распоряжений от него - не лучшее решение. Большинство `IDE` (даже под `windows`) умеют эмулировать терминал и сохранять отпечатанные ранее там символы даже после завершения отправившей их программы. Подробности смотрите в описании коммита.